### PR TITLE
Changes to match heka-py 0.30.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,4 @@
+0.3 - 2013-08-19
+================
+
+- Updated to use heka-py and the heka-raven library instead of metlog

--- a/README.rst
+++ b/README.rst
@@ -15,3 +15,16 @@ The advantage of doing so allows heka to act as a centralized client
 to route all logging messages.  This greatly simplifies testing as you
 can always just query the heka client to see what messages have been
 sent.
+
+How to run the testsuite:
+
+Due to the dependency on Django, you'll need to use the runtests.py
+script instead of just running nose.
+
+To run the tests, use ::
+
+    python runtests.py
+
+You can get a list of all command line options by using --help ::
+
+    python runtests.py --help

--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,17 @@
-===================
-django-raven-metlog
-===================
+=================
+django-raven-heka
+=================
 
-.. image:: https://secure.travis-ci.org/mozilla-services/django-raven-metlog.png
+.. image:: https://secure.travis-ci.org/mozilla-services/django-raven-heka.png
 
-django-raven-metlog is a set of plugins for the Raven client of Sentry
-to enable routing of raven messages through metlog when you are
+django-raven-heka is a set of plugins for the Raven client
+to enable routing of raven messages through heka when you are
 running a Django application.
 
-The primary use of this is to standardize metlog integration into
+The primary use of this is to standardize heka integration into
 `Playdoh <http://playdoh.readthedocs.org/>`_ applications.
 
-The advantage of doing so allows metlog to act as a centralized client
+The advantage of doing so allows heka to act as a centralized client
 to route all logging messages.  This greatly simplifies testing as you
-can always just query the metlog client to see what messages have been
-sent. 
-
-More information about how Mozilla Services is using Metlog (including what is
-being used for a router and what endpoints are in use / planning to be used)
-can be found on the relevant `spec page
-<https://wiki.mozilla.org/Services/Sagrada/Metlog>`_.
+can always just query the heka client to see what messages have been
+sent.

--- a/djangoraven/heka.py
+++ b/djangoraven/heka.py
@@ -18,15 +18,15 @@ from raven.contrib.django.client import DjangoClient
 
 try:
     from django.conf import settings
-    from metlog.client import SEVERITY
+    from heka.client import SEVERITY
 except:
     settings = None  # NOQA
     SEVERITY = None  # NOQA
 
-class MetlogDjangoClient(DjangoClient):
+class HekaDjangoClient(DjangoClient):
     """
     This client simply overrides the send_encoded method in the base
-    Client so that we use settings.METLOG for transmission
+    Client so that we use settings.HEKA for transmission
     """
 
     def is_enabled(self):
@@ -47,6 +47,6 @@ class MetlogDjangoClient(DjangoClient):
     def send_encoded(self, message, public_key=None, \
             auth_header=None, **kwargs):
         """
-        Given an already serialized message send it off to metlog
+        Given an already serialized message send it off to heka
         """
-        settings.METLOG.raven(payload=message)
+        settings.HEKA.raven(payload=message)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -77,17 +77,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/DjangoRavenMetlogintegration.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/DjangoRavenHekaintegration.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/DjangoRavenMetlogintegration.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/DjangoRavenHekaintegration.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/DjangoRavenMetlogintegration"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/DjangoRavenMetlogintegration"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/DjangoRavenHekaintegration"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/DjangoRavenHekaintegration"
 	@echo "# devhelp"
 
 epub:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ copyright = u'2012, Victor Ng'
 # built documents.
 #
 # The short X.Y version.
-version = '0.2'
+version = '0.3'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Django Raven Metlog integration documentation build configuration file, created by
+# Django Raven Heka integration documentation build configuration file, created by
 # sphinx-quickstart on Wed Nov 28 10:59:52 2012.
 #
 # This file is execfile()d with the current directory set to its containing dir.
@@ -40,7 +40,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Django Raven Metlog integration'
+project = u'Django Raven Heka integration'
 copyright = u'2012, Victor Ng'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -165,7 +165,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'DjangoRavenMetlogintegrationdoc'
+htmlhelp_basename = 'DjangoRavenHekaintegrationdoc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -184,7 +184,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'DjangoRavenMetlogintegration.tex', u'Django Raven Metlog integration Documentation',
+  ('index', 'DjangoRavenHekaintegration.tex', u'Django Raven Heka integration Documentation',
    u'Victor Ng', 'manual'),
 ]
 
@@ -214,7 +214,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'djangoravenmetlogintegration', u'Django Raven Metlog integration Documentation',
+    ('index', 'djangoravenhekaintegration', u'Django Raven Heka integration Documentation',
      [u'Victor Ng'], 1)
 ]
 
@@ -228,8 +228,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'DjangoRavenMetlogintegration', u'Django Raven Metlog integration Documentation', u'Victor Ng',
-   'DjangoRavenMetlogintegration', 'One line description of project.', 'Miscellaneous'),
+  ('index', 'DjangoRavenHekaintegration', u'Django Raven Heka integration Documentation', u'Victor Ng',
+   'DjangoRavenHekaintegration', 'One line description of project.', 'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,20 +1,20 @@
-Configuring Django with stacktraces routed through Metlog
-=========================================================
+Configuring Django with stacktraces routed through Heka
+=======================================================
 
-Integrating metlog into Django to capture stacktraces requires doing a
+Integrating heka into Django to capture stacktraces requires doing a
 couple things.
 
 1. Setup Raven+Django integration
-2. Setup Metlog clients
+2. Setup Heka clients
 3. Switch the standard Sentry client and instead use
-   MetlogDjangoClient
+   HekaDjangoClient
 
 Step 1
 ------
 
 Setup the sentry client (raven) for use with Django.
 
-Settings up raven with metlog is documented completely in the `raven-python
+Setting up raven is documented completely in the `raven-python
 documentation <http://raven.readthedocs.org/en/latest/>`.  To get the
 extra integration with Django, you will need to do the following
 steps:
@@ -23,7 +23,7 @@ steps:
 2.  Set SENTRY_CLIENT to 'raven.contrib.django.DjangoClient' in settings.py
 3.  Set the SENTRY_DSN in settings.py
 
-Here's what that'll look like in settings.py ::
+Here's a typical configuration in settings.py ::
 
     my_dsn = 'http://public:secret@example.com/1'
 
@@ -54,29 +54,27 @@ both the RAVEN_CONFIG and the SENTRY_DSN entries in settings.py
 Step 2
 ------
 
-Setup metlog with just the DebugCaptureSender.  Please refer to the full documentation on
-`configuring Metlog <http://metlog-py.rtfd.org>`_ to get a production
+Setup heka with just the DebugCaptureStream.  Please refer to the full documentation on
+`configuring heka <http://heka-py.rtfd.org>`_ to get a production
 setup.
 
 Add the following to your settings.py ::
 
-    METLOG_CONF = {
-        'sender': {
-            'class': 'metlog.senders.DebugCaptureSender',
-        },
+    HEKA_CONF = {
+        'stream_class': 'heka.streams.DebugCaptureStream',
     }
 
-    from metlog.config import client_from_dict_config
-    METLOG = client_from_dict_config(METLOG_CONF)
+    from heka.config import client_from_dict_config
+    HEKA = client_from_dict_config(HEKA_CONF)
 
 Step 3
 ------
 
-Reconfigure Raven to use metlog as it's underlying sentry client. Just
+Reconfigure Raven to use heka as it's underlying sentry client. Just
 change the SENTRY_CLIENT setting in settings.py to use the alternate
 SENTRY_CLIENT  ::
 
-    SENTRY_CLIENT = 'djangoraven.metlog.MetlogDjangoClient'
+    SENTRY_CLIENT = 'djangoraven.heka.HekaDjangoClient'
 
 Due to the way that raven sets a project_id variable for Sentry, you
 will need to explicitly set the SENTRY_DSN setting ::
@@ -84,11 +82,10 @@ will need to explicitly set the SENTRY_DSN setting ::
     SENTRY_DSN = "udp://your:dsn@goeshere.com:9001/2"
 
 At this point, you can safely remove the DSN entry in RAVEN_CONFIG.
-The MetlogDjangoClient does not need it.  Final routing of your
-stacktrace is handled by `logstash <http://logstash-metlog.rtfd.org/>`_
-or `heka <http://heka.rtfd.org/>`_.
+The HekaDjangoClient does not need it.  Final routing of your
+stacktrace is handled by `heka <http://heka.rtfd.org/>`_.
 
-That's it!  Your raven messages will route through metlog.
+That's it!  Your raven messages will route through heka.
 
 See the test suite to see how you can inspect messages when you're
 testing.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. Django Raven Metlog integration documentation master file, created by
+.. Django Raven Heka integration documentation master file, created by
    sphinx-quickstart on Wed Nov 28 10:59:52 2012.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ from setuptools import setup, find_packages
 version = '0.2'
 
 README = """
-django-raven-metlog is a set of plugins for the Raven client of Sentry
-to enable routing of raven messages through metlog when you are
+django-raven-heka is a set of plugins for the Raven client of Sentry
+to enable routing of raven messages through heka when you are
 running a Django application.
 """
 
@@ -29,25 +29,25 @@ tests_require = [
     'Django>=1.2,<1.5',
     'django-nose',
     'nose',
-    'metlog-py',
+    'heka-py',
     'mock',
     'pep8',
     'raven',
 ]
 
-setup(name='django-raven-metlog',
+setup(name='django-raven-heka',
       version=version,
       description="Django+Raven+Meltog integration",
       long_description=README,
-      keywords='django metlog raven sentry',
+      keywords='django heka raven sentry',
       author='Victor Ng',
       author_email='vng@mozilla.com',
-      url='https://github.com/mozilla-services/django-raven-metlog',
+      url='https://github.com/mozilla-services/django-raven-heka',
       license='MPLv2.0',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=['docopt', 'raven', 'metlog-raven>=0.4'],
+      install_requires=['docopt', 'raven', 'heka-raven>=0.4'],
       tests_require=tests_require,
       extras_require={'test': tests_require},
       test_suite='runtests.runtests',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '0.2'
+version = '0.3'
 
 README = """
 django-raven-heka is a set of plugins for the Raven client of Sentry
@@ -47,7 +47,7 @@ setup(name='django-raven-heka',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=False,
-      install_requires=['docopt', 'raven', 'heka-raven>=0.4'],
+      install_requires=['docopt', 'raven', 'heka-raven>=0.6'],
       tests_require=tests_require,
       extras_require={'test': tests_require},
       test_suite='runtests.runtests',

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -87,23 +87,12 @@ class DjangoHekaTransport(TestCase):
             * This is the actual heka client instance
         """
 
-        """
-        'sender': {
-            'class': 'heka.senders.UdpSender',
-            'host': '192.168.20.2',
-            'port': 5565,
-        },
-        """
         self.HEKA_CONF = {
-            'sender': {
-                'class': 'heka.senders.UdpSender',
-                'host': '192.168.20.2',
-                'port': 5565,
-            },
-            'plugins': {'raven':
-                ('heka_raven.raven_plugin:config_plugin', {'dsn':
-                    DSN})
-             },
+                'stream_class': 'heka.streams.DebugCaptureStream',
+                'plugins': {'raven':
+                    ('heka_raven.raven_plugin:config_plugin', {'dsn':
+                        DSN})
+                    },
         }
 
         self.SENTRY_CLIENT = 'djangoraven.heka.HekaDjangoClient'
@@ -121,7 +110,7 @@ class DjangoHekaTransport(TestCase):
 
             self.raven.capture('Message', message='foo')
 
-            msgs = settings.HEKA.sender.msgs
+            msgs = [m[8:] for m in settings.HEKA.sender.stream.msgs]
 
             self.assertEquals(len(msgs), 1)
             event = self.raven.decode(json.loads(msgs[0])['payload'])
@@ -157,7 +146,7 @@ class DjangoHekaTransport(TestCase):
             else:
                 self.fail('Expected an exception.')
 
-            msgs = settings.HEKA.sender.msgs
+            msgs = [m[8:] for m in settings.HEKA.sender.stream.msgs]
 
             self.assertEquals(len(msgs), 1)
 

--- a/tests/contrib/django/tests.py
+++ b/tests/contrib/django/tests.py
@@ -60,7 +60,7 @@ class Settings(object):
                 setattr(settings, k, v)
 
 
-class DjangoMetlogTransport(TestCase):
+class DjangoHekaTransport(TestCase):
     ## Fixture setup/teardown
     urls = 'tests.contrib.django.urls'
 
@@ -77,43 +77,43 @@ class DjangoMetlogTransport(TestCase):
               This is the control point that all messages are going
               to get routed through
 
-              For metlog integration, this *must* be
-              'raven_metlog.djangometlog.MetlogDjangoClient'
+              For heka integration, this *must* be
+              'raven_heka.djangoheka.HekaDjangoClient'
 
-        settings.METLOG_CONF :
-            * configuration for the metlog client instance
+        settings.HEKA_CONF :
+            * configuration for the heka client instance
 
-        settings.METLOG :
-            * This is the actual metlog client instance
+        settings.HEKA :
+            * This is the actual heka client instance
         """
 
         """
         'sender': {
-            'class': 'metlog.senders.UdpSender',
+            'class': 'heka.senders.UdpSender',
             'host': '192.168.20.2',
             'port': 5565,
         },
         """
-        self.METLOG_CONF = {
+        self.HEKA_CONF = {
             'sender': {
-                'class': 'metlog.senders.UdpSender',
+                'class': 'heka.senders.UdpSender',
                 'host': '192.168.20.2',
                 'port': 5565,
             },
             'plugins': {'raven':
-                ('metlog_raven.raven_plugin:config_plugin', {'dsn':
+                ('heka_raven.raven_plugin:config_plugin', {'dsn':
                     DSN})
              },
         }
 
-        self.SENTRY_CLIENT = 'djangoraven.metlog.MetlogDjangoClient'
+        self.SENTRY_CLIENT = 'djangoraven.heka.HekaDjangoClient'
 
-        from metlog.config import client_from_dict_config
-        self.METLOG = client_from_dict_config(self.METLOG_CONF)
+        from heka.config import client_from_dict_config
+        self.HEKA = client_from_dict_config(self.HEKA_CONF)
 
     def test_basic(self):
-        with Settings(METLOG_CONF=self.METLOG_CONF,
-                      METLOG=self.METLOG,
+        with Settings(HEKA_CONF=self.HEKA_CONF,
+                      HEKA=self.HEKA,
                       SENTRY_CLIENT=self.SENTRY_CLIENT,
                       SENTRY_DSN=DSN):
 
@@ -121,7 +121,7 @@ class DjangoMetlogTransport(TestCase):
 
             self.raven.capture('Message', message='foo')
 
-            msgs = settings.METLOG.sender.msgs
+            msgs = settings.HEKA.sender.msgs
 
             self.assertEquals(len(msgs), 1)
             event = self.raven.decode(json.loads(msgs[0])['payload'])
@@ -143,8 +143,8 @@ class DjangoMetlogTransport(TestCase):
             self.assertTrue(isinstance(event['timestamp'], basestring))
 
     def test_signal_integration(self):
-        with Settings(METLOG_CONF=self.METLOG_CONF,
-                      METLOG=self.METLOG,
+        with Settings(HEKA_CONF=self.HEKA_CONF,
+                      HEKA=self.HEKA,
                       SENTRY_CLIENT=self.SENTRY_CLIENT,
                       SENTRY_DSN=DSN):
 
@@ -157,7 +157,7 @@ class DjangoMetlogTransport(TestCase):
             else:
                 self.fail('Expected an exception.')
 
-            msgs = settings.METLOG.sender.msgs
+            msgs = settings.HEKA.sender.msgs
 
             self.assertEquals(len(msgs), 1)
 


### PR DESCRIPTION
Documentation, tests and API updates to match heka-py 0.30.1.

The  use of the metlog sender API has been changed to use the newer streams API in the test cases.  
